### PR TITLE
Use simple secrets store for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.zip
 /venv
+.idea
+.vscode

--- a/src/deployer.py
+++ b/src/deployer.py
@@ -143,6 +143,7 @@ class DockerJobDeployer(JobDeployer):
                          job_version: str,
                          job_secrets: JobSecrets,
                          ):
+        logger.warning('saving secrets in an ephemeral, in-memory store')
         self._secrets_store[f'{job_name}.{job_version}'] = job_secrets
 
     def get_job_secrets(self,

--- a/src/deployer.py
+++ b/src/deployer.py
@@ -26,8 +26,9 @@ logger = get_logger(__name__)
 class DockerJobDeployer(JobDeployer):
     """JobDeployer managing workloads on a local docker instance, used mostly for testing purposes"""
 
-    def __init__(self) -> None:
+    def __init__(self, secrets_store: dict[str, JobSecrets]) -> None:
         self.infrastructure_name = 'docker'
+        self._secrets_store: dict[str, JobSecrets] = secrets_store
 
     def deploy_job(
         self,
@@ -138,16 +139,19 @@ class DockerJobDeployer(JobDeployer):
         return 8000
 
     def save_job_secrets(self,
-                            job_name: str,
-                            job_version: str,
-                            job_secrets: JobSecrets,
-                            ):
-        raise NotImplementedError("managing secrets is not supported on local docker")
+                         job_name: str,
+                         job_version: str,
+                         job_secrets: JobSecrets,
+                         ):
+        self._secrets_store[f'{job_name}.{job_version}'] = job_secrets
 
     def get_job_secrets(self,
-                           job_name: str,
-                           job_version: str,
-                           ) -> JobSecrets:
+                        job_name: str,
+                        job_version: str,
+                        ) -> JobSecrets:
+        key = f'{job_name}.{job_version}'
+        if key in self._secrets_store:
+            return self._secrets_store[key]
         raise NotImplementedError("managing secrets is not supported on local docker")
 
     @staticmethod

--- a/src/plugin-manifest.yaml
+++ b/src/plugin-manifest.yaml
@@ -1,3 +1,3 @@
 name: docker-infrastructure
-version: 1.2.0
+version: 1.3.0
 url: https://github.com/TheRacetrack/plugin-docker-infrastructure

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -6,9 +6,12 @@ from racetrack_client.log.logs import get_logger
 
 if 'lifecycle' in sys.modules:
     from lifecycle.deployer.infra_target import InfrastructureTarget
+    from lifecycle.deployer.secrets import JobSecrets
     from deployer import DockerJobDeployer
     from monitor import DockerMonitor
     from logs_streamer import DockerLogsStreamer
+
+    secrets_store: dict[str, JobSecrets] = {}
 
 logger = get_logger(__name__)
 
@@ -22,7 +25,7 @@ class Plugin:
         """
         return {
             'docker': InfrastructureTarget(
-                job_deployer=DockerJobDeployer(),
+                job_deployer=DockerJobDeployer(secrets_store),
                 job_monitor=DockerMonitor(),
                 logs_streamer=DockerLogsStreamer(),
             ),


### PR DESCRIPTION
This improvement makes it able to test features like this https://github.com/TheRacetrack/racetrack/pull/251 locally.

It's not ideal, secrets are now stored in memory for a short time, but it's better than always saying that it's not supported at all and making redeployment impossible.